### PR TITLE
simple-comic fix download link

### DIFF
--- a/Casks/simple-comic.rb
+++ b/Casks/simple-comic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'simple-comic' do
   version '1.7_252'
   sha256 '4ddd18a02a79fc8201824e6ab99291c6d4c8680f79f94bc372bf71f0535def35'
 
-  # amazonaws.com is the official download host per the vendor homepage
-  url "http://dancingtortoisedownload.s3.amazonaws.com/SimpleComic_#{version}.zip"
+  # Mirror of the download link since vendor link is offline
+  url "https://andychase.github.io/Simple-Comic/SimpleComic_#{version}.zip"
   name 'Simple Comic'
   homepage 'http://dancingtortoise.com/simplecomic/'
   license :mit


### PR DESCRIPTION
The official link is offline and the creator hasn't been active since 2013, so I've created an alternate link to facilitate downloading this application.

Related Issues/PRs: 

* Issue: https://github.com/caskroom/homebrew-cask/issues/10988 
* Proposal to remove: https://github.com/caskroom/homebrew-cask/pull/10989 
* Upstream issue: https://github.com/arauchfuss/Simple-Comic/issues/101